### PR TITLE
add parse command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ilmentufa"]
+	path = ilmentufa
+	url = ../../lojban/ilmentufa.git

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,48 @@
+package samcu
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func parse(_ string, args []string) string {
+	if len(args) == 0 {
+		return ".i mo?"
+	}
+
+	parser := "-exp"
+	mode := "X"
+	parsers := map[string]bool{
+		"-std":    true,
+		"-beta":   true,
+		"-cbm":    true,
+		"-ckt":    true,
+		"-exp":    true,
+		"-morpho": true,
+	}
+
+	// Parse arguments:
+	for len(args) >= 1 && strings.HasPrefix(args[0], "-") {
+		if parsers[args[0]] {
+			parser = args[0]
+			args = args[1:]
+		} else if len(args) >= 2 && args[0] == "-m" {
+			mode = args[1]
+			args = args[2:]
+		} else {
+			break
+		}
+	}
+
+	// Run camxes:
+	text := strings.Join(args, " ")
+	cmd := exec.Command("node", "ilmentufa/run_camxes.js", parser, "-m", mode, text)
+	stdout, err := cmd.Output()
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok && strings.Contains(string(e.Stderr), "SyntaxError") {
+			return ".i .u'u na gendra"
+		}
+		return "failed to run camxes"
+	}
+	return strings.TrimSpace(string(stdout))
+}

--- a/respond.go
+++ b/respond.go
@@ -10,6 +10,7 @@ var handlers = map[string]func(string, []string) string{
 	"sisku": sisku,
 	"katna": katna,
 	"gloss": gloss,
+	"parse": parse,
 
 	"l": lujvo,
 	"r": rafsi,


### PR DESCRIPTION
Adds https://github.com/lojban/ilmentufa as a submodule, and adds a `parse` command to samcu that invokes it.

You can select a parser (e.g. `-ckt`) and mode (e.g. `-m C`).

Example output from the CLI:

```sh
% go run cli/cli.go
parse coi ro do
(coi [ro do])
parse -m C coi ro do
(COI:coi [PA:ro KOhA:do])
```